### PR TITLE
Added methods which get cluster list, topic identities, and partition identities

### DIFF
--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -11,6 +11,7 @@ CLI tools for accessing Krux Kafka Clusters
 #
 
 from __future__ import absolute_import
+from pprint import pformat
 
 #
 # Internal libraries
@@ -55,13 +56,8 @@ class Application(krux.cli.Application):
         pending_clusters = self.kafka_manager_api.get_cluster_list(params={"status": "pending"})
         self.logger.info(pending_clusters)
 
-        # for cluster in all_clusters:
-        #     for topic in get_topic_list:
-        #         self.logger.info('Cluster {cluster} - Topic {topic} - Broker Skew Percentage: {skew}'.format(
-        #                 cluster=cluster['name'],
-        #                 topic=topic,
-        #                 skew=self.kafka_manager_api.get_brokers_skew(cluster['name'], topic)
-        #             ))
+        topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
+        self.logger.info(pformat(topic_identities))
 
 
 def main():

--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -41,14 +41,8 @@ class Application(krux.cli.Application):
         group = krux.cli.get_group(parser, self.name)
 
     def run(self):
-        topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
-        self.logger.info(pformat(topic_identities))
-
-        get_cluster_list = self.kafka_manager_api.get_cluster_list(status='active')
+        get_cluster_list = self.kafka_manager_api.get_cluster_list()
         self.logger.info(pformat(get_cluster_list))
-
-        partitions_identity = self.kafka_manager_api.get_partitions_identity('krux-manager-test', '__consumer_offsets')
-        self.logger.info(pformat(partitions_identity))
 
 
 def main():

--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -41,14 +41,14 @@ class Application(krux.cli.Application):
         group = krux.cli.get_group(parser, self.name)
 
     def run(self):
-        # topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
-        # self.logger.info(pformat(topic_identities))
+        topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
+        self.logger.info(pformat(topic_identities))
 
         get_cluster_list = self.kafka_manager_api.get_cluster_list(status='active')
         self.logger.info(pformat(get_cluster_list))
 
-        # partitions_identity = self.kafka_manager_api.get_partitions_identity('krux-manager-test', '__consumer_offsets')
-        # self.logger.info(pformat(partitions_identity))
+        partitions_identity = self.kafka_manager_api.get_partitions_identity('krux-manager-test', '__consumer_offsets')
+        self.logger.info(pformat(partitions_identity))
 
 
 def main():

--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -42,7 +42,13 @@ class Application(krux.cli.Application):
 
     def run(self):
         topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
-        self.logger.info(topic_identities)
+        self.logger.info(pformat(topic_identities))
+
+        get_cluster_list = self.kafka_manager_api.get_cluster_list(params=None, status='pending')
+        self.logger.info(pformat(get_cluster_list))
+
+        partitions_identity = self.kafka_manager_api.get_partitions_identity('krux-manager-test', 'test')
+        self.logger.info(pformat(partitions_identity))
 
 
 def main():

--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -44,10 +44,10 @@ class Application(krux.cli.Application):
         topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
         self.logger.info(pformat(topic_identities))
 
-        get_cluster_list = self.kafka_manager_api.get_cluster_list(params=None, status='pending')
+        get_cluster_list = self.kafka_manager_api.get_cluster_list(params=None, status='active')
         self.logger.info(pformat(get_cluster_list))
 
-        partitions_identity = self.kafka_manager_api.get_partitions_identity('krux-manager-test', 'test')
+        partitions_identity = self.kafka_manager_api.get_partitions_identity('krux-manager-test', '__consumer_offsets')
         self.logger.info(pformat(partitions_identity))
 
 

--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -41,14 +41,14 @@ class Application(krux.cli.Application):
         group = krux.cli.get_group(parser, self.name)
 
     def run(self):
-        topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
-        self.logger.info(pformat(topic_identities))
+        # topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
+        # self.logger.info(pformat(topic_identities))
 
-        get_cluster_list = self.kafka_manager_api.get_cluster_list(params=None, status='active')
+        get_cluster_list = self.kafka_manager_api.get_cluster_list(status='active')
         self.logger.info(pformat(get_cluster_list))
 
-        partitions_identity = self.kafka_manager_api.get_partitions_identity('krux-manager-test', '__consumer_offsets')
-        self.logger.info(pformat(partitions_identity))
+        # partitions_identity = self.kafka_manager_api.get_partitions_identity('krux-manager-test', '__consumer_offsets')
+        # self.logger.info(pformat(partitions_identity))
 
 
 def main():

--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -13,10 +13,6 @@ CLI tools for accessing Krux Kafka Clusters
 from __future__ import absolute_import
 
 #
-# Third party libraries
-#
-
-#
 # Internal libraries
 #
 

--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -41,23 +41,8 @@ class Application(krux.cli.Application):
         group = krux.cli.get_group(parser, self.name)
 
     def run(self):
-        get_brokers_skew = self.kafka_manager_api.get_brokers_skew('krux-manager-test', 'test')
-        self.logger.info(get_brokers_skew)
-
-        get_topic_list = self.kafka_manager_api.get_topic_list('krux-manager-test')
-        self.logger.info(get_topic_list)
-
-        all_clusters = self.kafka_manager_api.get_cluster_list()
-        self.logger.info(all_clusters)
-
-        active_clusters = self.kafka_manager_api.get_cluster_list(params={"status": "active"})
-        self.logger.info(active_clusters)
-
-        pending_clusters = self.kafka_manager_api.get_cluster_list(params={"status": "pending"})
-        self.logger.info(pending_clusters)
-
         topic_identities = self.kafka_manager_api.get_topic_identities('krux-manager-test')
-        self.logger.info(pformat(topic_identities))
+        self.logger.info(topic_identities)
 
 
 def main():

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -87,30 +87,9 @@ class KafkaManagerAPI(object):
         request_cluster_list = requests.get('{hostname}/api/status/clusters'.format(hostname=self._hostname), params=params)
         return request_cluster_list.json()['clusters']
 
-    def get_topic_list(self, cluster):
-        """
-        Returns dictionary containing list of topics for given cluster
-        """
-        request_topic_list = requests.get('{hostname}/api/status/{cluster}/topics'.format(hostname=self._hostname, cluster=cluster))
-        return request_topic_list.json()['topics']
-
     def get_topic_identities(self, cluster):
         """
         Returns dictionary containing list of topic identities for given cluster
         """
         request_topic_identities = requests.get('{hostname}/api/status/{cluster}/topicIdentities'.format(hostname=self._hostname, cluster=cluster))
         return request_topic_identities.json()['topicIdentities']
-
-    def get_brokers_skew(self, cluster, topic):
-        """
-        Returns brokers skew percentage for the given cluster and topic.
-
-        :argument cluster: Kafka cluster name as a string
-        :argument topic: Kafka topic name as a string
-        """
-        request_brokers_skew = requests.get('{hostname}/api/status/{cluster}/{topic}/brokersSkewPercentage'.format(
-            hostname=self._hostname,
-            cluster=cluster,
-            topic=topic
-            ))
-        return request_brokers_skew.json()['brokersSkewPercentage']

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -84,5 +84,9 @@ class KafkaManagerAPI(object):
         """
         Returns brokers skew percentage for the given cluster and topic.
         """
-        r = requests.get('{hostname}/api/status/{cluster}/{topic}/brokersSkewPercentage'.format(self._hostname, cluster, topic))
+        r = requests.get('{hostname}/api/status/{cluster}/{topic}/brokersSkewPercentage'.format(
+            hostname=self._hostname,
+            cluster=cluster,
+            topic=topic
+            ))
         return r.json()['brokersSkewPercentage']

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -98,12 +98,6 @@ class KafkaManagerAPI(object):
         """
         request_topic_identities = requests.get('{hostname}/api/status/{cluster}/topicIdentities'.format(hostname=self._hostname, cluster=cluster))
         topic_identities = request_topic_identities.json()['topicIdentities']
-        for topic_identity in topic_identities:
-            partitions_identity = []
-            for partition_id, partition_vals in topic_identity['partitionsIdentity'].iteritems():
-                partitions_identity.append(partition_vals)
-            partitions_identity = sorted(partitions_identity, key=lambda x: x['partNum'])
-            topic_identity['partitionsIdentity'] = partitions_identity
         return topic_identities
 
     def get_partitions_identity(self, cluster, topic):

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -80,12 +80,12 @@ class KafkaManagerAPI(object):
         self._stats = stats or get_stats(prefix=self._name)
         self._hostname = hostname
 
-    def get_cluster_list(self, params=None, status=None):
+    def get_cluster_list(self, status=None):
         """
         Returns list containing dictionaries of information for each cluster. User can filter for clusters
         with certain status, else all clusters are returned.
         """
-        request_cluster_list = requests.get('{hostname}/api/status/clusters'.format(hostname=self._hostname), params=params)
+        request_cluster_list = requests.get('{hostname}/api/status/clusters'.format(hostname=self._hostname))
         cluster_list = request_cluster_list.json()['clusters']
         if status:
             return cluster_list[status]

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -111,4 +111,7 @@ class KafkaManagerAPI(object):
         Returns list of partition identities for topic of given cluster.
         """
         topic_identities = self.get_topic_identities(cluster)
-        return [topic_identity['partitionsIdentity'] for topic_identity in topic_identities if topic_identity['topic'] == topic]
+        for topic_identity in topic_identities:
+            if topic_identity['topic'] == topic:
+                return topic_identity['partitionsIdentity']
+        return []

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -54,7 +54,7 @@ def add_kafka_manager_api_cli_arguments(parser):
     """
     Utility function for adding Kafka Manager specific CLI arguments.
     """
-    # Add those specific to the application    
+    # Add those specific to the application
     group = get_group(parser, NAME)
 
     group.add_argument(
@@ -81,5 +81,8 @@ class KafkaManagerAPI(object):
         self._hostname = hostname
 
     def get_brokers_skew(self, cluster, topic):
-        r = requests.get('%s/api/status/%s/%s/brokersSkewPercentage' % (self._hostname, cluster, topic))
+        """
+        Returns brokers skew percentage for the given cluster and topic.
+        """
+        r = requests.get('{hostname}/api/status/{cluster}/{topic}/brokersSkewPercentage'.format(self._hostname, cluster, topic))
         return r.json()['brokersSkewPercentage']

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -94,6 +94,13 @@ class KafkaManagerAPI(object):
         request_topic_list = requests.get('{hostname}/api/status/{cluster}/topics'.format(hostname=self._hostname, cluster=cluster))
         return request_topic_list.json()['topics']
 
+    def get_topic_identities(self, cluster):
+        """
+        Returns dictionary containing list of topic identities for given cluster
+        """
+        request_topic_identities = requests.get('{hostname}/api/status/{cluster}/topicIdentities'.format(hostname=self._hostname, cluster=cluster))
+        return request_topic_identities.json()['topicIdentities']
+
     def get_brokers_skew(self, cluster, topic):
         """
         Returns brokers skew percentage for the given cluster and topic.

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -99,13 +99,3 @@ class KafkaManagerAPI(object):
         request_topic_identities = requests.get('{hostname}/api/status/{cluster}/topicIdentities'.format(hostname=self._hostname, cluster=cluster))
         topic_identities = request_topic_identities.json()['topicIdentities']
         return topic_identities
-
-    def get_partitions_identity(self, cluster, topic):
-        """
-        Returns list of partition identities for topic of given cluster.
-        """
-        topic_identities = self.get_topic_identities(cluster)
-        for topic_identity in topic_identities:
-            if topic_identity['topic'] == topic:
-                return topic_identity['partitionsIdentity']
-        return []

--- a/krux_kafka_manager/kafka_manager_api.py
+++ b/krux_kafka_manager/kafka_manager_api.py
@@ -93,8 +93,7 @@ class KafkaManagerAPI(object):
 
     def get_topic_identities(self, cluster):
         """
-        Returns dictionary containing list of topic identities for given cluster. Partitions identity formatted
-        into ordered list for easier use.
+        Returns dictionary containing list of topic identities for given cluster.
         """
         request_topic_identities = requests.get('{hostname}/api/status/{cluster}/topicIdentities'.format(hostname=self._hostname, cluster=cluster))
         topic_identities = request_topic_identities.json()['topicIdentities']

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 
 # We use the version to construct the DOWNLOAD_URL.
 
-VERSION = '0.0.1'
+VERSION = '0.1.0'
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/krux/python-krux-kafka-manager'

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -15,7 +15,7 @@ import sys
 # Third party libraries
 #
 
-from mock import MagicMock, patch
+from mock import MagicMock, patch, call
 
 #
 # Internal libraries
@@ -29,6 +29,7 @@ from krux_kafka_manager.kafka_manager_api import KafkaManagerAPI
 class CLItest(unittest.TestCase):
 
     _BROKER_SKEW_INT = 0
+    _EXAMPLE_LIST = ['1', '2', '3']
 
     @patch('krux_kafka_manager.cli.krux.cli.krux.logging.get_logger')
     @patch('krux_kafka_manager.cli.get_kafka_manager_api')
@@ -62,13 +63,13 @@ class CLItest(unittest.TestCase):
 
     def test_run(self):
         """
-        CLI Test: Kafka Manager API's get_brokers_skew method is correctly called in self.app.run()
+        CLI Test: Kafka Manager API's get_topic_identities method is correctly called in self.app.run()
         """
-        self.mock_get_manager().get_brokers_skew.return_value = CLItest._BROKER_SKEW_INT
+        self.mock_get_manager().get_topic_identities.return_value = CLItest._EXAMPLE_LIST
         self.app.run()
 
-        self.mock_get_manager().get_brokers_skew.assert_called_once_with('krux-manager-test', 'test')
-        self.mock_get_logger().info.assert_called_once_with(CLItest._BROKER_SKEW_INT)
+        self.mock_get_manager().get_topic_identities.assert_called_once_with('krux-manager-test')
+        self.mock_get_logger().info.assert_called_once_with(CLItest._EXAMPLE_LIST)
 
     def test_main(self):
         """

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -28,9 +28,6 @@ from krux_kafka_manager.kafka_manager_api import KafkaManagerAPI
 
 class CLItest(unittest.TestCase):
 
-    _BROKER_SKEW_INT = 0
-    _EXAMPLE_LIST = ['1', '2', '3']
-
     @patch('krux_kafka_manager.cli.krux.cli.krux.logging.get_logger')
     @patch('krux_kafka_manager.cli.get_kafka_manager_api')
     @patch('sys.argv', ['krux-kafka', 'http://localhost:9000'])

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -65,11 +65,8 @@ class CLItest(unittest.TestCase):
         """
         CLI Test: Kafka Manager API's get_topic_identities method is correctly called in self.app.run()
         """
-        self.mock_get_manager().get_topic_identities.return_value = CLItest._EXAMPLE_LIST
         self.app.run()
-
-        self.mock_get_manager().get_topic_identities.assert_called_once_with('krux-manager-test')
-        self.mock_get_logger().info.assert_called_once_with(CLItest._EXAMPLE_LIST)
+        self.mock_get_manager().get_cluster_list.assert_called_once_with()
 
     def test_main(self):
         """

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -27,10 +27,10 @@ from krux_kafka_manager.kafka_manager_api import KafkaManagerAPI, get_kafka_mana
 class KafkaManagerTest(unittest.TestCase):
 
     _HOSTNAME = 'test_hostname'
-    CLUSTER = 'cluster'
+    CLUSTER = 'cluster_name'
     TOPIC = 'topic_name'
     STATUS = 'active' 
-    CLUSTER_LIST_STATUS_RV =  [{'name': 'cluster1'}]
+    CLUSTER_LIST_STATUS_RV =  [{'name': CLUSTER}]
     CLUSTER_LIST_RV = {STATUS: CLUSTER_LIST_STATUS_RV}
     CLUSTER_LIST_STATUS = {'clusters': CLUSTER_LIST_RV}
     TOPIC_IDENTITIES_RV =  [{'topic': TOPIC, 'partitionsIdentity': [{'partNum': 0}, {'partNum': 1}, {'partNum': 2}]}]

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -29,19 +29,12 @@ class KafkaManagerTest(unittest.TestCase):
     _HOSTNAME = 'test_hostname'
     CLUSTER = 'cluster'
     TOPIC = 'topic_name'
-    STATUS = 'active'
-    CLUSTER_LIST_REQUEST = {'clusters':[{'name': 'cluster1', 'status': 'active'}]}
-    CLUSTER_LIST_STATUS = {
-            'clusters': { 
-                'active': [{'name': 'cluster1', 'status': 'active'}],
-                'pending': [{'name': 'cluster2', 'status': 'pending'}]
-            }
-        }
-    CLUSTER_LIST_RV =  [{'name': 'cluster1', 'status': 'active'}]
-    TOPIC_IDENTITIES_REQUEST = {'topicIdentities': [{'topic':'topic_name', 'partitionsIdentity':
-                        [{'partNum': 0}, {'partNum': 1}, {'partNum': 2}]}]}
-    TOPIC_IDENTITIES_RV =  [{'topic':'topic_name', 'partitionsIdentity': [{'partNum': 0}, {'partNum': 1}, {'partNum': 2}]}]
-    PARTITIONS_IDENTITY_RV = [{'partNum': 0}, {'partNum': 1}, {'partNum': 2}]
+    STATUS = 'active' 
+    CLUSTER_LIST_STATUS_RV =  [{'name': 'cluster1'}]
+    CLUSTER_LIST_RV = {STATUS: CLUSTER_LIST_STATUS_RV}
+    CLUSTER_LIST_STATUS = {'clusters': CLUSTER_LIST_RV}
+    TOPIC_IDENTITIES_RV =  [{'topic': TOPIC, 'partitionsIdentity': [{'partNum': 0}, {'partNum': 1}, {'partNum': 2}]}]
+    TOPIC_IDENTITIES_REQUEST = {'topicIdentities': TOPIC_IDENTITIES_RV}
 
     @patch('krux_kafka_manager.kafka_manager_api.get_stats')
     @patch('krux_kafka_manager.kafka_manager_api.get_logger')
@@ -116,7 +109,6 @@ class KafkaManagerTest(unittest.TestCase):
         with no user inputs provided (except mandatory hostname argument)
         """
         mock_parser.return_value.parse_args.return_value = MagicMock(hostname=KafkaManagerTest._HOSTNAME)
-        mock_kafka_manager.return_value = MagicMock()
         manager = get_kafka_manager_api()
         mock_cli_args.assert_called_once_with(mock_parser(description=NAME))
         mock_kafka_manager.assert_called_once_with(
@@ -130,7 +122,7 @@ class KafkaManagerTest(unittest.TestCase):
         """
         Kafka Manager API Test: Checks if get_cluster_list method correctly returns list of clusters for hostname.
         """
-        mock_requests.get.return_value.json.return_value = KafkaManagerTest.CLUSTER_LIST_REQUEST
+        mock_requests.get.return_value.json.return_value = KafkaManagerTest.CLUSTER_LIST_STATUS
         cluster_list = self.manager.get_cluster_list()
         mock_requests.get.assert_called_once_with('{hostname}/api/status/clusters'.format(
             hostname=KafkaManagerTest._HOSTNAME))
@@ -142,7 +134,7 @@ class KafkaManagerTest(unittest.TestCase):
         cluster_list = self.manager.get_cluster_list(status=KafkaManagerTest.STATUS)
         mock_requests.get.assert_called_once_with('{hostname}/api/status/clusters'.format(
             hostname=KafkaManagerTest._HOSTNAME))
-        self.assertEqual(cluster_list, KafkaManagerTest.CLUSTER_LIST_RV)
+        self.assertEqual(cluster_list, KafkaManagerTest.CLUSTER_LIST_STATUS_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
     def test_get_topic_identities(self, mock_requests):

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -37,7 +37,8 @@ class KafkaManagerTest(unittest.TestCase):
 
     def test_KafkaManagerAPI_all_init(self):
         """
-        Checks if KafkaManagerAPI initialized property if all user inputs provided
+        Kafka Manager API Test: Checks if KafkaManagerAPI initialized property if all user
+        inputs provided.
         """
         manager = KafkaManagerAPI(KafkaManagerTest._HOSTNAME, self.mock_logger, self.mock_stats)
         self.assertIn(KafkaManagerTest._HOSTNAME, manager._hostname)
@@ -47,7 +48,8 @@ class KafkaManagerTest(unittest.TestCase):
 
     def test_KafkaManagerAPI_only_hostname(self):
         """
-        Checks if KafkaManagerAPI initialized properly with no user inputs except (required) hostname
+        Kafka Manager API Test: Checks if KafkaManagerAPI initialized properly with no user 
+        inputs except (required) hostname.
         """
         self.mock_logger.assert_called_once_with(self.manager._name)
         self.mock_stats.assert_called_once_with(prefix=self.manager._name)
@@ -55,8 +57,8 @@ class KafkaManagerTest(unittest.TestCase):
     @patch('krux_kafka_manager.kafka_manager_api.KafkaManagerAPI')
     def test_get_kafka_manager_api_all_inputs(self, mock_kafka_manager):
         """
-        Checks if get_kafka_manager_api initalizes KafkaManagerAPI object with all user inputs provided
-        (except mandatory hostname argument)
+        Checks if get_kafka_manager_api initalizes KafkaManagerAPI object with all user inputs
+        provided (except mandatory hostname argument).
         """
         mock_kafka_manager.return_value = MagicMock()
         mock_args = MagicMock(hostname=KafkaManagerTest._HOSTNAME)
@@ -74,8 +76,8 @@ class KafkaManagerTest(unittest.TestCase):
     @patch('krux_kafka_manager.kafka_manager_api.KafkaManagerAPI')
     def test_get_kafka_api_no_inputs(self, mock_kafka_manager, mock_cli_args, mock_parser, mock_logger, mock_stats):
         """
-        Checks if get_kafka_manager_api initalizes KafkaManagerAPI object with no user inputs provided
-        (except mandatory hostname argument)
+        Kafka Manager API Test: Checks if get_kafka_manager_api initalizes KafkaManagerAPI object
+        with no user inputs provided (except mandatory hostname argument)
         """
         mock_parser.return_value.parse_args.return_value = MagicMock(hostname=KafkaManagerTest._HOSTNAME)
         manager = get_kafka_manager_api()
@@ -95,8 +97,8 @@ class KafkaManagerTest(unittest.TestCase):
     @patch('krux_kafka_manager.kafka_manager_api.KafkaManagerAPI')
     def test_get_kafka_api_no_inputs(self, mock_kafka_manager, mock_cli_args, mock_parser, mock_logger, mock_stats):
         """
-        Checks if get_kafka_manager_api initalizes KafkaManagerAPI object with no user inputs provided
-        (except mandatory hostname argument)
+        Kafka Manager API Test: Checks if get_kafka_manager_api initalizes KafkaManagerAPI object
+        with no user inputs provided (except mandatory hostname argument)
         """
         mock_parser.return_value.parse_args.return_value = MagicMock(hostname='test_hostname')
         mock_kafka_manager.return_value = MagicMock()
@@ -109,11 +111,52 @@ class KafkaManagerTest(unittest.TestCase):
             )
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
+    def test_get_cluster_list(self, mock_requests):
+        """
+        Kafka Manager API Test: Checks if get_cluster_list method correctly returns list of clusters for hostname.
+        """
+        mock_requests.get.return_value.json.return_value = {'clusters':[{'name': 'cluster1', 'status': 'active'}]}
+        cluster_list = self.manager.get_cluster_list('params')
+        mock_requests.get.assert_called_once_with('{hostname}/api/status/clusters'.format(
+            hostname=KafkaManagerTest._HOSTNAME), params='params')
+        self.assertEqual(cluster_list, [{'name': 'cluster1', 'status': 'active'}])
+
+    @patch('krux_kafka_manager.kafka_manager_api.requests')
+    def test_get_topic_list(self, mock_requests):
+        """
+        Kafka Manager API Test: Checks if get_topic_list method correctly returns list of topic names for
+        given cluster.
+        """
+        mock_requests.get.return_value.json.return_value = {'topics': ['topic1', 'topic2']}
+        topic_list = self.manager.get_topic_list('cluster')
+        mock_requests.get.assert_called_once_with('{hostname}/api/status/{cluster}/topics'.format(
+            hostname=KafkaManagerTest._HOSTNAME,
+            cluster='cluster'))
+        self.assertEqual(topic_list, ['topic1', 'topic2'])
+
+    @patch('krux_kafka_manager.kafka_manager_api.requests')
+    def test_get_topic_identities(self, mock_requests):
+        """
+        Kafka Manager API Test: Checks if get_topic_identities method correctly returns topic identities
+        for all topics for given cluster.
+        """
+        mock_requests.get.return_value.json.return_value = {'topicIdentities':[{'topic':'topic_name','partitions':50,'numBrokers':1}]}
+        topic_identities = self.manager.get_topic_identities('cluster')
+        mock_requests.get.assert_called_once_with('{hostname}/api/status/{cluster}/topicIdentities'.format(
+            hostname=KafkaManagerTest._HOSTNAME,
+            cluster='cluster'))
+        self.assertEqual(topic_identities, [{'topic':'topic_name','partitions':50,'numBrokers':1}])
+
+    @patch('krux_kafka_manager.kafka_manager_api.requests')
     def test_get_brokers_skew(self, mock_requests):
         """
-        Checks if get_brokers_skew method correctly returns brokersSkewPercentage for given cluster and topic
+        Kafka Manager API Test: Checks if get_brokers_skew method correctly returns brokersSkewPercentage
+        for given cluster and topic
         """
         mock_requests.get.return_value.json.return_value = {'topics':'test','brokersSkewPercentage':0}
-        test_case = KafkaManagerAPI(KafkaManagerTest._HOSTNAME)
-        brokers_skew = test_case.get_brokers_skew('cluster', 'test')
+        brokers_skew = self.manager.get_brokers_skew('cluster', 'test')
+        mock_requests.get.assert_called_once_with('{hostname}/api/status/{cluster}/{topic}/brokersSkewPercentage'.format(
+            hostname=KafkaManagerTest._HOSTNAME,
+            cluster='cluster',
+            topic='test'))
         self.assertEqual(brokers_skew, 0)

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -122,6 +122,19 @@ class KafkaManagerTest(unittest.TestCase):
         self.assertEqual(cluster_list, [{'name': 'cluster1', 'status': 'active'}])
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
+    def test_get_cluster_list_status(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = {
+            'clusters': { 
+                'active': [{'name': 'cluster1', 'status': 'active'}],
+                'pending': [{'name': 'cluster2', 'status': 'pending'}]
+            }
+        }
+        cluster_list = self.manager.get_cluster_list(params=None, status='pending')
+        mock_requests.get.assert_called_once_with('{hostname}/api/status/clusters'.format(
+            hostname=KafkaManagerTest._HOSTNAME), params=None)
+        self.assertEqual(cluster_list, [{'name': 'cluster2', 'status': 'pending'}])
+
+    @patch('krux_kafka_manager.kafka_manager_api.requests')
     def test_get_topic_identities(self, mock_requests):
         """
         Kafka Manager API Test: Checks if get_topic_identities method correctly returns topic identities

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -169,6 +169,10 @@ class KafkaManagerTest(unittest.TestCase):
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
     def test_get_partitions_identity_valid_input(self, mock_requests):
+        """
+        Kafka Manager API Test: Checks if get_partitions_identity finds correct partitions identity for given
+        cluster and topic.
+        """
         self.manager.get_topic_identities = MagicMock(return_value = KafkaManagerTest.TOPIC_IDENTITIES_RV)
         partitions_identity = self.manager.get_partitions_identity(KafkaManagerTest.CLUSTER, KafkaManagerTest.TOPIC)
         self.manager.get_topic_identities.assert_called_once_with(KafkaManagerTest.CLUSTER)
@@ -176,6 +180,10 @@ class KafkaManagerTest(unittest.TestCase):
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
     def test_get_partitions_identity_invalid_input(self, mock_requests):
+        """
+        Kafka Manager API Test: Checks if get_partitions_identity returns empty list if topic does not
+        exist in topic identities.
+        """
         self.manager.get_topic_identities = MagicMock(return_value = KafkaManagerTest.TOPIC_IDENTITIES_RV)
         partitions_identity = self.manager.get_partitions_identity(KafkaManagerTest.CLUSTER, 'wrong_topic')
         self.manager.get_topic_identities.assert_called_once_with(KafkaManagerTest.CLUSTER)

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -146,7 +146,7 @@ class KafkaManagerTest(unittest.TestCase):
         self.assertEqual(cluster_list, KafkaManagerTest.CLUSTER_LIST_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_topic_identities(self, mock_requests): #FIX
+    def test_get_topic_identities(self, mock_requests):
         """
         Kafka Manager API Test: Checks if get_topic_identities method correctly returns topic identities
         for all topics for given cluster, and organizes partitionsIdentity into list of dictionaries
@@ -160,7 +160,7 @@ class KafkaManagerTest(unittest.TestCase):
         self.assertEqual(topic_identities, KafkaManagerTest.TOPIC_IDENTITIES_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_partitions_identity_valid_input(self, mock_requests): #FIX
+    def test_get_partitions_identity_valid_input(self, mock_requests):
         """
         Kafka Manager API Test: Checks if get_partitions_identity finds correct partitions identity for given
         cluster and topic.
@@ -172,7 +172,7 @@ class KafkaManagerTest(unittest.TestCase):
         self.assertEqual(partitions_identity, KafkaManagerTest.PARTITIONS_IDENTITY_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_partitions_identity_invalid_input(self, mock_requests): #FIX
+    def test_get_partitions_identity_invalid_input(self, mock_requests):
         """
         Kafka Manager API Test: Checks if get_partitions_identity returns empty list if topic does not
         exist in topic identities.

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -29,7 +29,6 @@ class KafkaManagerTest(unittest.TestCase):
     _HOSTNAME = 'test_hostname'
     CLUSTER = 'cluster'
     TOPIC = 'topic_name'
-    PARAMS = 'params'
     STATUS = 'active'
     CLUSTER_LIST_REQUEST = {'clusters':[{'name': 'cluster1', 'status': 'active'}]}
     CLUSTER_LIST_STATUS = {
@@ -132,17 +131,17 @@ class KafkaManagerTest(unittest.TestCase):
         Kafka Manager API Test: Checks if get_cluster_list method correctly returns list of clusters for hostname.
         """
         mock_requests.get.return_value.json.return_value = KafkaManagerTest.CLUSTER_LIST_REQUEST
-        cluster_list = self.manager.get_cluster_list(KafkaManagerTest.PARAMS)
+        cluster_list = self.manager.get_cluster_list()
         mock_requests.get.assert_called_once_with('{hostname}/api/status/clusters'.format(
-            hostname=KafkaManagerTest._HOSTNAME), params=KafkaManagerTest.PARAMS)
+            hostname=KafkaManagerTest._HOSTNAME))
         self.assertEqual(cluster_list, KafkaManagerTest.CLUSTER_LIST_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
     def test_get_cluster_list_status(self, mock_requests):
         mock_requests.get.return_value.json.return_value = KafkaManagerTest.CLUSTER_LIST_STATUS
-        cluster_list = self.manager.get_cluster_list(params=None, status=KafkaManagerTest.STATUS)
+        cluster_list = self.manager.get_cluster_list(status=KafkaManagerTest.STATUS)
         mock_requests.get.assert_called_once_with('{hostname}/api/status/clusters'.format(
-            hostname=KafkaManagerTest._HOSTNAME), params=None)
+            hostname=KafkaManagerTest._HOSTNAME))
         self.assertEqual(cluster_list, KafkaManagerTest.CLUSTER_LIST_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -48,7 +48,7 @@ class KafkaManagerTest(unittest.TestCase):
 
     def test_KafkaManagerAPI_only_hostname(self):
         """
-        Kafka Manager API Test: Checks if KafkaManagerAPI initialized properly with no user 
+        Kafka Manager API Test: Checks if KafkaManagerAPI initialized properly with no user
         inputs except (required) hostname.
         """
         self.mock_logger.assert_called_once_with(self.manager._name)
@@ -122,19 +122,6 @@ class KafkaManagerTest(unittest.TestCase):
         self.assertEqual(cluster_list, [{'name': 'cluster1', 'status': 'active'}])
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_topic_list(self, mock_requests):
-        """
-        Kafka Manager API Test: Checks if get_topic_list method correctly returns list of topic names for
-        given cluster.
-        """
-        mock_requests.get.return_value.json.return_value = {'topics': ['topic1', 'topic2']}
-        topic_list = self.manager.get_topic_list('cluster')
-        mock_requests.get.assert_called_once_with('{hostname}/api/status/{cluster}/topics'.format(
-            hostname=KafkaManagerTest._HOSTNAME,
-            cluster='cluster'))
-        self.assertEqual(topic_list, ['topic1', 'topic2'])
-
-    @patch('krux_kafka_manager.kafka_manager_api.requests')
     def test_get_topic_identities(self, mock_requests):
         """
         Kafka Manager API Test: Checks if get_topic_identities method correctly returns topic identities
@@ -146,17 +133,3 @@ class KafkaManagerTest(unittest.TestCase):
             hostname=KafkaManagerTest._HOSTNAME,
             cluster='cluster'))
         self.assertEqual(topic_identities, [{'topic':'topic_name','partitions':50,'numBrokers':1}])
-
-    @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_brokers_skew(self, mock_requests):
-        """
-        Kafka Manager API Test: Checks if get_brokers_skew method correctly returns brokersSkewPercentage
-        for given cluster and topic
-        """
-        mock_requests.get.return_value.json.return_value = {'topics':'test','brokersSkewPercentage':0}
-        brokers_skew = self.manager.get_brokers_skew('cluster', 'test')
-        mock_requests.get.assert_called_once_with('{hostname}/api/status/{cluster}/{topic}/brokersSkewPercentage'.format(
-            hostname=KafkaManagerTest._HOSTNAME,
-            cluster='cluster',
-            topic='test'))
-        self.assertEqual(brokers_skew, 0)

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -90,27 +90,6 @@ class KafkaManagerTest(unittest.TestCase):
         mock_parser.return_value.parse_args.return_value = MagicMock(hostname=KafkaManagerTest._HOSTNAME)
         manager = get_kafka_manager_api()
         mock_cli_args.assert_called_once_with(mock_parser(description=NAME))
-        mock_logger.assert_called_once_with(name=NAME)
-        mock_stats.assert_called_once_with(prefix=NAME)
-        mock_kafka_manager.assert_called_once_with(
-            hostname = KafkaManagerTest._HOSTNAME,
-            logger=mock_logger(name=NAME),
-            stats=mock_stats(prefix=NAME),
-            )
-
-    @patch('krux_kafka_manager.kafka_manager_api.get_stats')
-    @patch('krux_kafka_manager.kafka_manager_api.get_logger')
-    @patch('krux_kafka_manager.kafka_manager_api.get_parser')
-    @patch('krux_kafka_manager.kafka_manager_api.add_kafka_manager_api_cli_arguments')
-    @patch('krux_kafka_manager.kafka_manager_api.KafkaManagerAPI')
-    def test_get_kafka_api_no_inputs(self, mock_kafka_manager, mock_cli_args, mock_parser, mock_logger, mock_stats):
-        """
-        Kafka Manager API Test: Checks if get_kafka_manager_api initalizes KafkaManagerAPI object
-        with no user inputs provided (except mandatory hostname argument)
-        """
-        mock_parser.return_value.parse_args.return_value = MagicMock(hostname=KafkaManagerTest._HOSTNAME)
-        manager = get_kafka_manager_api()
-        mock_cli_args.assert_called_once_with(mock_parser(description=NAME))
         mock_kafka_manager.assert_called_once_with(
             hostname = KafkaManagerTest._HOSTNAME,
             logger=mock_logger(name=NAME),

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -157,28 +157,3 @@ class KafkaManagerTest(unittest.TestCase):
             hostname=KafkaManagerTest._HOSTNAME,
             cluster=KafkaManagerTest.CLUSTER))
         self.assertEqual(topic_identities, KafkaManagerTest.TOPIC_IDENTITIES_RV)
-
-    @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_partitions_identity_valid_input(self, mock_requests):
-        """
-        Kafka Manager API Test: Checks if get_partitions_identity finds correct partitions identity for given
-        cluster and topic.
-        """
-        manager = KafkaManagerAPI(hostname=KafkaManagerTest._HOSTNAME)
-        manager.get_topic_identities = MagicMock(return_value=KafkaManagerTest.TOPIC_IDENTITIES_RV)
-        partitions_identity = manager.get_partitions_identity(KafkaManagerTest.CLUSTER, KafkaManagerTest.TOPIC)
-        manager.get_topic_identities.assert_called_once_with(KafkaManagerTest.CLUSTER)
-        self.assertEqual(partitions_identity, KafkaManagerTest.PARTITIONS_IDENTITY_RV)
-
-    @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_partitions_identity_invalid_input(self, mock_requests):
-        """
-        Kafka Manager API Test: Checks if get_partitions_identity returns empty list if topic does not
-        exist in topic identities.
-        """
-        manager = KafkaManagerAPI(hostname=KafkaManagerTest._HOSTNAME)
-        manager.get_topic_identities = MagicMock(return_value=KafkaManagerTest.TOPIC_IDENTITIES_RV)
-        partitions_identity = manager.get_partitions_identity(KafkaManagerTest.CLUSTER, 'wrong_topic')
-        manager.get_topic_identities.assert_called_once_with(KafkaManagerTest.CLUSTER)
-        self.assertEqual(partitions_identity, [])
-

--- a/test/kafka_manager_api_test.py
+++ b/test/kafka_manager_api_test.py
@@ -39,17 +39,9 @@ class KafkaManagerTest(unittest.TestCase):
             }
         }
     CLUSTER_LIST_RV =  [{'name': 'cluster1', 'status': 'active'}]
-    TOPIC_IDENTITIES_REQUEST = {
-            'topicIdentities':[
-                {
-                    'topic':'topic_name',
-                    'partitionsIdentity': {'2': {'partNum': 2}, '1': {'partNum': 1}, '0': {'partNum': 0}}
-                }
-            ]
-        }
-    TOPIC_IDENTITIES_RV = [
-                    {'topic':'topic_name', 'partitionsIdentity': [
-                        {'partNum': 0}, {'partNum': 1}, {'partNum': 2}]}]
+    TOPIC_IDENTITIES_REQUEST = {'topicIdentities': [{'topic':'topic_name', 'partitionsIdentity':
+                        [{'partNum': 0}, {'partNum': 1}, {'partNum': 2}]}]}
+    TOPIC_IDENTITIES_RV =  [{'topic':'topic_name', 'partitionsIdentity': [{'partNum': 0}, {'partNum': 1}, {'partNum': 2}]}]
     PARTITIONS_IDENTITY_RV = [{'partNum': 0}, {'partNum': 1}, {'partNum': 2}]
 
     @patch('krux_kafka_manager.kafka_manager_api.get_stats')
@@ -154,7 +146,7 @@ class KafkaManagerTest(unittest.TestCase):
         self.assertEqual(cluster_list, KafkaManagerTest.CLUSTER_LIST_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_topic_identities(self, mock_requests):
+    def test_get_topic_identities(self, mock_requests): #FIX
         """
         Kafka Manager API Test: Checks if get_topic_identities method correctly returns topic identities
         for all topics for given cluster, and organizes partitionsIdentity into list of dictionaries
@@ -168,24 +160,26 @@ class KafkaManagerTest(unittest.TestCase):
         self.assertEqual(topic_identities, KafkaManagerTest.TOPIC_IDENTITIES_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_partitions_identity_valid_input(self, mock_requests):
+    def test_get_partitions_identity_valid_input(self, mock_requests): #FIX
         """
         Kafka Manager API Test: Checks if get_partitions_identity finds correct partitions identity for given
         cluster and topic.
         """
-        self.manager.get_topic_identities = MagicMock(return_value = KafkaManagerTest.TOPIC_IDENTITIES_RV)
-        partitions_identity = self.manager.get_partitions_identity(KafkaManagerTest.CLUSTER, KafkaManagerTest.TOPIC)
-        self.manager.get_topic_identities.assert_called_once_with(KafkaManagerTest.CLUSTER)
+        manager = KafkaManagerAPI(hostname=KafkaManagerTest._HOSTNAME)
+        manager.get_topic_identities = MagicMock(return_value=KafkaManagerTest.TOPIC_IDENTITIES_RV)
+        partitions_identity = manager.get_partitions_identity(KafkaManagerTest.CLUSTER, KafkaManagerTest.TOPIC)
+        manager.get_topic_identities.assert_called_once_with(KafkaManagerTest.CLUSTER)
         self.assertEqual(partitions_identity, KafkaManagerTest.PARTITIONS_IDENTITY_RV)
 
     @patch('krux_kafka_manager.kafka_manager_api.requests')
-    def test_get_partitions_identity_invalid_input(self, mock_requests):
+    def test_get_partitions_identity_invalid_input(self, mock_requests): #FIX
         """
         Kafka Manager API Test: Checks if get_partitions_identity returns empty list if topic does not
         exist in topic identities.
         """
-        self.manager.get_topic_identities = MagicMock(return_value = KafkaManagerTest.TOPIC_IDENTITIES_RV)
-        partitions_identity = self.manager.get_partitions_identity(KafkaManagerTest.CLUSTER, 'wrong_topic')
-        self.manager.get_topic_identities.assert_called_once_with(KafkaManagerTest.CLUSTER)
+        manager = KafkaManagerAPI(hostname=KafkaManagerTest._HOSTNAME)
+        manager.get_topic_identities = MagicMock(return_value=KafkaManagerTest.TOPIC_IDENTITIES_RV)
+        partitions_identity = manager.get_partitions_identity(KafkaManagerTest.CLUSTER, 'wrong_topic')
+        manager.get_topic_identities.assert_called_once_with(KafkaManagerTest.CLUSTER)
         self.assertEqual(partitions_identity, [])
 


### PR DESCRIPTION
Added the following getter methods to kafka_manager_api.py: get_cluster_list and get_topic_identities. get_cluster_list allows user to filter for active or pending clusters. Added tests to kafka_manager_api_test for these functions.