### PR TITLE
Omit protocol from hostname

### DIFF
--- a/krux_kafka_manager/cli.py
+++ b/krux_kafka_manager/cli.py
@@ -38,7 +38,6 @@ class Application(krux.cli.Application):
         super(Application, self).add_cli_arguments(parser)
 
         add_kafka_manager_api_cli_arguments(parser)
-        group = krux.cli.get_group(parser, self.name)
 
     def run(self):
         get_cluster_list = self.kafka_manager_api.get_cluster_list()

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -9,7 +9,6 @@
 
 from __future__ import absolute_import
 import unittest
-import sys
 
 #
 # Third party libraries
@@ -23,7 +22,6 @@ from mock import MagicMock, patch, call
 
 from krux.stats import DummyStatsClient
 from krux_kafka_manager.cli import Application, NAME, main
-from krux_kafka_manager.kafka_manager_api import KafkaManagerAPI
 
 
 class CLItest(unittest.TestCase):
@@ -60,7 +58,7 @@ class CLItest(unittest.TestCase):
 
     def test_run(self):
         """
-        CLI Test: Kafka Manager API's get_topic_identities method is correctly called in self.app.run()
+        CLI Test: Kafka Manager API's get_cluster_list method is correctly called in self.app.run()
         """
         self.app.run()
         self.mock_get_manager().get_cluster_list.assert_called_once_with()


### PR DESCRIPTION
## What does this PR do?
This PR changes how hostname is used, so that user can quickly go from HTTP to HTTPS and can omit the protocol from the hostname parameter.
This PR also includes various code clean up.

## Why is this change being made?
Hostname field shouldn't include `http://` portion. That should be deduced from the library.

## How was this tested? How can the reviewer verify your testing?
The change is manually tested on the development environment and via unit tests.

## Where should the reviewer start?
`krux_kafka_manager/kafka_manager_api.py`

## Completion checklist

- [x] The pull request has been appropriately labelled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The change has unit & integration tests as appropriate.